### PR TITLE
fix: update validate_env to support MONGO_URI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,13 @@ jobs:
           echo "MONGO_PASSWORD=${{secrets.MONGO_PASSWORD}}" >> .env
           echo "MONGO_USERNAME=${{secrets.MONGO_USERNAME}}" >> .env
           echo "MONGO_HOST=${{secrets.MONGO_HOST}}" >> .env
-          echo "SECRET_KEY=${{secrets.SECRET_KEY}}" >> .env
+
+          # Use secret if available, otherwise use test fallback
+          if [ -n "${{secrets.SECRET_KEY}}" ]; then
+            echo "SECRET_KEY=${{secrets.SECRET_KEY}}" >> .env
+          else
+            echo "SECRET_KEY=test-secret-key-for-ci" >> .env
+          fi
 
           # Non-critical hardcoded values for testing
           echo "PASSWORD_ALGORITHM=HS256" >> .env

--- a/app/utils/validate_env.py
+++ b/app/utils/validate_env.py
@@ -4,10 +4,25 @@ from app.config import Settings, get_settings
 def validate_env(settings: Settings | None = None):
     if settings is None:
         settings = get_settings()
+
+    # Check MongoDB configuration: either MONGO_URI or individual fields
+    has_mongo_uri = bool(settings.mongo_uri)
+    has_mongo_individual = all(
+        [
+            settings.mongo_username,
+            settings.mongo_password,
+            settings.mongo_host,
+        ]
+    )
+
+    if not has_mongo_uri and not has_mongo_individual:
+        raise RuntimeError(
+            "Missing MongoDB configuration: provide either MONGO_URI or "
+            "all of MONGO_USERNAME, MONGO_PASSWORD, and MONGO_HOST"
+        )
+
+    # Check other required variables
     required_vars = {
-        "MONGO_USERNAME": settings.mongo_username,
-        "MONGO_PASSWORD": settings.mongo_password,
-        "MONGO_HOST": settings.mongo_host,
         "MONGO_DATABASE": settings.mongo_db,
         "MONGO_TODO_COLLECTION": settings.mongo_todo_collection,
         "MONGO_USER_COLLECTION": settings.mongo_user_collection,
@@ -20,4 +35,5 @@ def validate_env(settings: Settings | None = None):
     missing = [name for name, value in required_vars.items() if not value]
     if missing:
         raise RuntimeError(f"Missing required environment variables: {missing}")
+
     return settings


### PR DESCRIPTION
- validate_env now accepts MONGO_URI as alternative to individual fields
- CI workflow uses fallback SECRET_KEY when secrets unavailable
- Enables Dependabot PRs to pass CI