### PR TITLE
refactor: remove redundant MongoDB validation from validate_env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ users_collection = request.app.user
 - **DON'T** modify `ARCHITECTURE.md` without discussion first
 - **DON'T** create ADRs before updating `ARCHITECTURE.md`
 - **DON'T** hardcode secrets—use environment variables via `app/config.py`
+- **DON'T** duplicate validation logic—Pydantic `model_validator` in `config.py` is the single source of truth for env validation. Don't re-check the same constraints elsewhere.
 
 ### 🛑 Agent Commit Rules
 

--- a/app/utils/validate_env.py
+++ b/app/utils/validate_env.py
@@ -2,26 +2,16 @@ from app.config import Settings, get_settings
 
 
 def validate_env(settings: Settings | None = None):
+    """Validate required environment variables.
+
+    Note: MongoDB connection validation (MONGO_URI vs individual fields)
+    is handled by the Pydantic model_validator in config.py.
+    This function only validates other required fields.
+    """
     if settings is None:
-        settings = get_settings()
+        settings = get_settings()  # Pydantic validates mongo config here
 
-    # Check MongoDB configuration: either MONGO_URI or individual fields
-    has_mongo_uri = bool(settings.mongo_uri)
-    has_mongo_individual = all(
-        [
-            settings.mongo_username,
-            settings.mongo_password,
-            settings.mongo_host,
-        ]
-    )
-
-    if not has_mongo_uri and not has_mongo_individual:
-        raise RuntimeError(
-            "Missing MongoDB configuration: provide either MONGO_URI or "
-            "all of MONGO_USERNAME, MONGO_PASSWORD, and MONGO_HOST"
-        )
-
-    # Check other required variables
+    # Check other required variables (mongo config validated by Pydantic)
     required_vars = {
         "MONGO_DATABASE": settings.mongo_db,
         "MONGO_TODO_COLLECTION": settings.mongo_todo_collection,


### PR DESCRIPTION
MongoDB config validation (MONGO_URI vs individual fields) is already handled by the Pydantic model_validator in config.py. Removing duplicate check from validate_env.py as suggested in PR #78 review.

Also added guidance to AGENTS.md to prevent this pattern in the future.